### PR TITLE
Fix LaTeX Snippets for vscode

### DIFF
--- a/21HS/DM/Summaries/01_summary_2022_01_17.md
+++ b/21HS/DM/Summaries/01_summary_2022_01_17.md
@@ -6,8 +6,8 @@
 
 | Begriff               | Erklärung    |
 | --------------------- | ------------ |
-| $\top$ (Tautologie)   | immer wahr   |
-| $\bot$ (Wiederspruch) | immer falsch |
+| $\top$ (Tautologie)   | immer wahr   |
+| $\bot$ (Wiederspruch) | immer falsch |
 | $\vee$                | oder         |
 | $\wedge$              | und          |
 

--- a/21HS/DM/Summaries/01_summary_2022_01_17.md
+++ b/21HS/DM/Summaries/01_summary_2022_01_17.md
@@ -207,11 +207,11 @@ Findet die Möchtigkeit einer Prime Restklassen heraus:
 Es gibt garantiert eine Lösung, wenn alle Modulos paarweise teilerfremd sind (alle mit allen den $ggT$ von $1$ haben)
 
 Beispiel, um zu sehen, wie $a_1$ und $m_1$ zustande kommen:
-$$
-x\equiv_3 2 &\rightarrow &a_1=2&m_1=3\\
-x\equiv_5 7 &\rightarrow &a_2=3 &m_2=5\\
-x\equiv_7 2 &\rightarrow&a_3=2 &m_3=7\\
-$$
+$$\begin{aligned}
+  x\equiv_3 2 & \rightarrow &a_1=2 &m_1=3\\
+  x\equiv_5 7 & \rightarrow &a_2=3 &m_2=5\\
+  x\equiv_7 2 & \rightarrow &a_3=2 &m_3=7
+\end{aligned}$$
 
 
 1. $M_k$ berechnen: $M_k=\frac{\sum_i m_i}{m_k}$
@@ -224,8 +224,10 @@ Für $(p \in \R \wedge a \in \Z)\wedge p \not{|} a$ gillt $a^{p-1}\equiv 1 \mod 
 
 > Beispiel: 
 >
-> $$
+> $$\begin{aligned}
+> \begin{gathered}
 > 26^{123}\mod 7 & ggT(26, 7)=1\\
 > 26^{7-1}\equiv_7 26^6\equiv_7 1\\
 > 26^{123}\equiv_7 (26^6)^{20}\cdot 26^3\equiv_7 1^20\cdot 26^3\equiv_7 5^3\equiv_7(-2^3) \equiv_7 -8 \equiv_76
-> $$
+> \end{gathered}
+> \end{aligned}$$


### PR DESCRIPTION
This PR will fix LaTeX snippets to work in vscode's markdown parser properly.