### PR TITLE
Fix Further LaTeX Syntax for vscode & Add Support for MarkdownConverter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 Current Semester/
+out/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "markdownConverter.DestinationPattern": "${workspaceFolder}/out/${dirname}/${basename}.${extension}",
+    "markdownConverter.Parser.Toc.Indicator": "^\\[TOC\\]"
+}

--- a/21HS/DM/Summaries/01_summary_2022_01_17.md
+++ b/21HS/DM/Summaries/01_summary_2022_01_17.md
@@ -107,7 +107,7 @@ Bindung: $\neg, \wedge, \vee, \Rightarrow, \Leftrightarrow$
 | Wohldefiniertheit                      | Eine Funktion, welche eine Äquivalenzrelation als Argument nimmt, ist wohldefiniert, wenn $xRy \Rightarrow F(x)=F(y)$ bedeutet.                                                              |
 | Äquivalenzrelationen                   | Eine reflexive, symmetrische und transitive Relation, in welcher alle Elemente zu einander eine Beziehung haben                                                                              |
 | Restklasse                             | Eine Menge von Elementen in einer Äquivalenzrelation, welche miteinander verbunden                                                                                                           |
-| $x\equiv_5y $                          | $(x - y) \text{ ist ein vielfaches von 5}$                                                                                                                                                   |
+| $x\equiv_5y$                           | $(x - y) \text{ ist ein vielfaches von 5}$                                                                                                                                                   |
 | transitiver Abschluss ($R^+$)          | Eine Relation $R^+$, enhält zusätzlich zu R, alle Relation, damit R transitiv wird                                                                                                           |
 | reflexiv-transitiven Abschluss ($R^*$) | Eine Relation $R^*$, enhält zusätzlich zu $R^+$, alle Relationen, damit $R^+$ reflexiv wird.                                                                                                 |
 | DAG                                    | Ein gerichteten zyklenfreien Graphen ist ein Graph, welcher keine zyklen enhält                                                                                                              |
@@ -150,7 +150,7 @@ Es gibt eine Aussage $A(n), n\in \N$, welche wahr sein soll.
 
 | Begriff                         | Erklärung                                                                                                                                                                             |
 | ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| $x                              | y$                                                                                                                                                                                    | X teilt y (achtung Reihenfolge) |
+| $x\|y$                          | X teilt y (achtung Reihenfolge) |
 | $T(x)$                          | Menge aller Teile von $x$ ($T(15)=\{1, 3, 5, 15\}$)                                                                                                                                   |
 | $\pi(n)$                        | Wie viel Primzahlen kleiner als n sind                                                                                                                                                |
 | Prime Restklassen ($\Z^*_{/7}$) | Eine Menge von Elementen mit einem multiplikativen inversem Element                                                                                                                   |
@@ -167,6 +167,7 @@ Es gibt eine Aussage $A(n), n\in \N$, welche wahr sein soll.
 * $ggT(n, m)=a\cdot n + b \cdot m$, wenn $x\neq y$ und $a,b \in \N$
 
 <img src="res/image-20220116125106959.png" alt="image-20220116125106959" style="float: right" />
+
 Um das $kgV(x, y)$ zu bestimmen, wird eine Primfaktorzerlegung von $x$ und $y$ durchgeführt. Danach werden die höchsten Potenzen zusammen gerechnet.
 Für den $ggT$ werden die tiefsten Potenzen verwendet.
 


### PR DESCRIPTION
This PR will fix further LaTeX snippets to work in vscode. Furthermore settings for converting markdown files to `.pdf`s inside vscode are added.